### PR TITLE
Fix for offcanvas menu

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,4 +16,11 @@
 //= require turbolinks
 //= require_tree .
 
-$(function(){ $(document).foundation(); });
+var loadFoundation = function() {
+    $(document).foundation();
+}
+
+$(document).on('page:load', function(){
+    loadFoundation();
+});
+$(loadFoundation);


### PR DESCRIPTION
When Turbolinks automagically loads the new page, the handlers added by the `foundation()` function no longer correspond to elements currently on the page. To load the handlers for the new page, when Turbolinks loads a new page the `foundation()` function is called.
