### PR TITLE
Accordion content in off-canvas menu

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,11 +3,27 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_action :setup_offcanvas_menu
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :full_name])
+  end
+
+  private
+
+  def setup_offcanvas_menu
+    #TODO: Refactor @menu_scores to be more performant. Calling User.all.sort_by is not scalable.
+    @menu_scores            = User.all
+                                  .sort_by{|a,b| a.battles_won.count <=> b.battles_won.count if [a,b].all?}
+                                  .first(5)
+    @menu_battles           = Battle.order(:created_at)
+                                    .last(5)
+    @menu_commented_battles = Battle.joins(:comments)
+                                    .group("comments.battle_id")
+                                    .order("count(comments.battle_id) desc")
+                                    .limit(5)
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,10 +23,22 @@
               = link_to "Edit #{current_user.full_name}", edit_user_registration_path
               | 
               = link_to "Sign Out", destroy_user_session_path, method: :delete
-          %ul.vertical.menu
-            %li= link_to "BATTLES", battles_path
-            %li= link_to "TAGS", tags_path
-            %li= link_to "COMMENTS", comments_path
+          %ul.vertical.menu{:"data-accordion-menu" => true}
+            %li
+              = link_to "SCOREBOARD", "#"
+              %ul.menu.vertical.nested
+                - @menu_scores.each do |score|
+                  %li= link_to "#{score.full_name}: #{score.battles_won.count}", "#"
+            %li
+              = link_to "RECENT BATTLES", battles_path
+              %ul.menu.vertical.nested
+                - @menu_battles.each do |battle|
+                  %li= link_to "#{battle.topic.upcase}", battle_path(battle)
+            %li
+              = link_to "MOST COMMENTED", "#"
+              %ul.menu.vertical.nested
+                - @menu_commented_battles.each do |commented_battle|
+                  %li= link_to "#{commented_battle.topic.upcase}: #{commented_battle.comments.count}", battle_path(commented_battle)
         .off-canvas-content{:"data-off-canvas-content" => true}
           %button.button{type: 'button', :"data-toggle" => "off-canvas-left-menu"}= fa_icon 'bars'
           .row


### PR DESCRIPTION
Adding beginnings of menu content:
- Scoreboard - lists 5 most-winning Gifwar users (controller query needs work, but this effort was more focused on getting the UI in place than building the most effective SQL statements)
- Recent Battles - last 5 Battles when sorted by the `created_at` date
- Most Commented - top 5 Battles according to the number of comments received
