### PR TITLE
Modified offcanvas and fixed bar

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -17,9 +17,22 @@
  */
 
 html, body,.off-canvas-wrapper,.off-canvas-wrapper-inner{
-    min-height:100vh;
+  min-height:100vh;
 }
 
 html, body,.off-canvas-wrapper,.off-canvas-wrapper-inner, .off-canvas-content{
-    min-height:100vh;
+  min-height:100vh;
+}
+
+article {
+  overflow-y: auto;
+}
+
+article,body,html,.off-canvas-wrapper,.off-canvas-wrapper-inner,.off-canvas,.off-canvas-content,.row{
+  height: 100%;
+  width: 100%;
+}
+
+.top-bar{
+  width: 100%;
 }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,7 +14,7 @@
   %body
     .off-canvas-wrapper
       .off-canvas-wrapper-inner{:"data-off-canvas-wrapper" => true}
-        #off-canvas-left-menu.off-canvas.position-left{:"data-off-canvas" => true}
+        #offCanvas.off-canvas.position-left{:"data-off-canvas" => true}
           .text-center
             - if current_user.nil?
               = link_to "Sign In", new_user_session_path
@@ -47,7 +47,10 @@
                   - @menu_scores.each do |score|
                     %li= link_to "#{score.full_name}: #{score.battles_won.count}", "#"
         .off-canvas-content{:"data-off-canvas-content" => true}
-          %button.button{type: 'button', :"data-toggle" => "off-canvas-left-menu"}= fa_icon 'bars'
-          .row
+          %div{:"data-sticky-container" => true}
+            .top-bar{"data-btm-anchor" => "content:bottom", "data-options" => "marginTop:0;", :"data-sticky" => true, "data-top-anchor" => "1"}
+              .top-bar-left.small-12.columns
+                %button.left.menu-icon{"data-toggle" => "offCanvas", :type => "button"}     
+          %article
             .small-12
               = yield


### PR DESCRIPTION
Proposed change of the top bar where now it goes all the way across, still has the hamburger icon on the left side, the bar is fixed at the top so it follows you when scrolling, when pressed it doesn't force you to to the top, shows the offcanvas menu show its content based on where you're located so you can go back to your original location without scrolling, and displays GIFWAR on the right side of the bar.

A buffer still needs to be placed so that the fixed bar doesn't overlap so if need be we can go back to just the icon if the bar all the way across is decided against. 
